### PR TITLE
Remove EOL distributions

### DIFF
--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -46,22 +46,6 @@ Components: main
 SignWith: F473DD4473365DE1
 Tracking: minimal
 
-# cosmic has support until july 2019
-Origin: matrix.org
-Codename: cosmic
-Architectures: amd64 i386 source
-Components: main
-SignWith: F473DD4473365DE1
-Tracking: minimal
-
-# disco has support until january 2020
-Origin: matrix.org
-Codename: disco
-Architectures: amd64 i386 source
-Components: main
-SignWith: F473DD4473365DE1
-Tracking: minimal
-
 # eoan has support until july 2020
 Origin: matrix.org
 Codename: eoan

--- a/debian/conf/incoming
+++ b/debian/conf/incoming
@@ -1,4 +1,4 @@
 Name: incoming
 IncomingDir: incoming
 TempDir: tmp
-Allow: stretch buster bullseye sid xenial bionic cosmic disco eoan focal
+Allow: stretch buster bullseye sid xenial bionic eoan focal


### PR DESCRIPTION
Ubuntu Cosmic and Disco are both EOL (as of July 2019 and January 2020, respectively).