### PR TITLE
Add Ubuntu 21.04 Hirsute Hippo

### DIFF
--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -85,3 +85,11 @@ Architectures: amd64 i386 source
 Components: main
 SignWith: F473DD4473365DE1
 Tracking: minimal
+
+# hirsute (21.04) reaches EOL on 2021-07-07
+Origin: matrix.org
+Codename: hirsute
+Architectures: amd64 source
+Components: main
+SignWith: F473DD4473365DE1
+Tracking: minimal

--- a/debian/conf/incoming
+++ b/debian/conf/incoming
@@ -1,4 +1,4 @@
 Name: incoming
 IncomingDir: incoming
 TempDir: tmp
-Allow: stretch buster bullseye sid xenial bionic cosmic disco eoan focal groovy
+Allow: stretch buster bullseye sid xenial bionic cosmic disco eoan focal groovy hirsute


### PR DESCRIPTION
Heads up: this also drops `i386` from the `Architectures` line of the `distributions` file for this distro.

I don't see _any_ artifacts that aren't `amd_64` in [our pool](https://packages.matrix.org/debian/pool/main/m/matrix-synapse-py3/), so I'd expect it to be fine.

Signed-off-by: Dan Callahan <danc@element.io>