### PR TITLE
Add a keyring package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /packages.matrix.org/debian/pool
 /packages.matrix.org/npm/*/*.tgz
 /packages.matrix.org/npm/*/*.tgz.asc
+/matrix-org-archive-keyring.deb
+/matrix-org-archive-keyring/usr/share/keyrings/

--- a/build_keyring_deb.sh
+++ b/build_keyring_deb.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Builds a keyring deb and imports it into the local reprepro DB. 
+#
+# NOTE: If you update the key you will need to bump the version in
+# `matrix-org-archive-keyring/DEBIAN/control`.
+
+set -euo pipefail
+
+mkdir -p matrix-org-archive-keyring/usr/share/keyrings/
+
+echo "Downloading keyring.gpg..."
+wget "https://packages.matrix.org/debian/matrix-org-archive-keyring.gpg" -O matrix-org-archive-keyring/usr/share/keyrings/matrix-org-archive-keyring.gpg
+
+echo "Downloaded key:"
+gpg --import --import-options show-only matrix-org-archive-keyring/usr/share/keyrings/matrix-org-archive-keyring.gpg
+
+read -p "Press any key to continue..."
+
+echo "Building deb..."
+dpkg-deb --build matrix-org-archive-keyring matrix-org-archive-keyring.deb
+
+for dist in $(ls -1 "packages.matrix.org/debian/dists")
+do
+	echo "Importing deb into $dist..."
+	reprepro -b debian/ -C "main"  includedeb  $dist matrix-org-archive-keyring.deb
+	reprepro -b debian/ -C "prerelease"  includedeb  $dist matrix-org-archive-keyring.deb
+done
+
+echo "Done!"

--- a/matrix-org-archive-keyring/DEBIAN/control
+++ b/matrix-org-archive-keyring/DEBIAN/control
@@ -1,0 +1,7 @@
+Package: matrix-org-archive-keyring
+Architecture: all
+Section: contrib/meta
+Maintainer: Synapse Packaging team <packages@matrix.org>
+Priority: optional
+Version: 1.0
+Description: The matrix.org package repository keyring


### PR DESCRIPTION
Step 1 of https://github.com/matrix-org/synapse/issues/10389

This just uses `dpkg-deb` to build the deb, rather than the standard tooling, mainly for simplicity. 

This does *not* update the key expiry time, just packaging up the existing public key.