### PR TITLE
Ensure we install keyring with right permissions

### DIFF
--- a/build_keyring_deb.sh
+++ b/build_keyring_deb.sh
@@ -18,7 +18,9 @@ gpg --import --import-options show-only matrix-org-archive-keyring/usr/share/key
 read -p "Press any key to continue..."
 
 echo "Building deb..."
-dpkg-deb --build matrix-org-archive-keyring matrix-org-archive-keyring.deb
+# Ensure that we add the keyring with the right permissions.
+chmod u=rw,go=r matrix-org-archive-keyring/usr/share/keyrings/matrix-org-archive-keyring.gpg
+dpkg-deb --root-owner-group --build matrix-org-archive-keyring matrix-org-archive-keyring.deb
 
 for dist in $(ls -1 "packages.matrix.org/debian/dists")
 do

--- a/matrix-org-archive-keyring/DEBIAN/control
+++ b/matrix-org-archive-keyring/DEBIAN/control
@@ -3,5 +3,5 @@ Architecture: all
 Section: contrib/meta
 Maintainer: Synapse Packaging team <packages@matrix.org>
 Priority: optional
-Version: 1.0
+Version: 1.1
 Description: The matrix.org package repository keyring


### PR DESCRIPTION
I've also bumped the version as I pushed a new release of the keyring package with this fix.

Introduced in #16