### PR TITLE
Update `download-latest-release.sh` to point to `element-hq/synapse`

### DIFF
--- a/download-latest-release.sh
+++ b/download-latest-release.sh
@@ -4,7 +4,7 @@
 # and extracts it into debian/incoming/.
 set -euo pipefail
 
-RELEASE_JSON=$( curl -s "https://api.github.com/repos/matrix-org/synapse/releases" | jq '.[0]' )
+RELEASE_JSON=$( curl -s "https://api.github.com/repos/element-hq/synapse/releases" | jq '.[0]' )
 
 VERSION=$( echo $RELEASE_JSON | jq -r '.name' )
 DOWNLOAD_URL=$( echo $RELEASE_JSON | jq -r '.assets | .[] | select(.name == "debs.tar.xz") | .browser_download_url' )


### PR DESCRIPTION
Otherwise you might end up downloading v1.98, and nobody wants that!

Context: https://element.io/blog/synapse-now-lives-at-github-com-element-hq-synapse/