### PR TITLE
Make `download-latest-release.sh` more portable

### DIFF
--- a/download-latest-release.sh
+++ b/download-latest-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Downloads the Debian tarball from the latest Synapse release on GitHub
 # and extracts it into debian/incoming/.


### PR DESCRIPTION
This script doesn't need `bash`, only `sh`.

This actually matters on my OS (NixOS), which doesn't put bash at `/bin/bash`. it does have a `/bin/sh` though.