### PR TITLE
Correctly use a portable bash shebang

### DIFF
--- a/download-latest-release.sh
+++ b/download-latest-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Downloads the Debian tarball from the latest Synapse release on GitHub
 # and extracts it into debian/incoming/.


### PR DESCRIPTION
We need `bash` not `sh`, was changed in https://github.com/matrix-org/pkg-repo-configs/pull/23

c.f. @anoadragon453 