### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request reviews from the synapse-core team when a pull request comes in.
+* @matrix-org/synapse-core


### PR DESCRIPTION
So that we don't miss incoming PRs, such as https://github.com/matrix-org/pkg-repo-configs/pull/25.